### PR TITLE
Add CraftyController client and status endpoint

### DIFF
--- a/ZeeKer.Crafty.Bot/Controllers/CraftyStatusController.cs
+++ b/ZeeKer.Crafty.Bot/Controllers/CraftyStatusController.cs
@@ -1,0 +1,40 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using ZeeKer.Crafty.Infrastructure.Clients;
+
+namespace ZeeKer.Crafty.Bot.Controllers;
+
+[ApiController]
+[Route("crafty")]
+public class CraftyStatusController : ControllerBase
+{
+    private readonly ICraftyControllerClient _craftyControllerClient;
+    private readonly ILogger<CraftyStatusController> _logger;
+
+    public CraftyStatusController(ICraftyControllerClient craftyControllerClient, ILogger<CraftyStatusController> logger)
+    {
+        _craftyControllerClient = craftyControllerClient;
+        _logger = logger;
+    }
+
+    [HttpGet("online")]
+    public async Task<IActionResult> GetOnlineAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var totalOnline = await _craftyControllerClient.GetTotalOnlineAsync(cancellationToken);
+            return Ok(new { totalOnline });
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve CraftyController data.");
+            return StatusCode(StatusCodes.Status502BadGateway, new { error = "Failed to retrieve data from CraftyController." });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "CraftyController configuration error.");
+            return StatusCode(StatusCodes.Status500InternalServerError, new { error = ex.Message });
+        }
+    }
+}

--- a/ZeeKer.Crafty.Bot/Program.cs
+++ b/ZeeKer.Crafty.Bot/Program.cs
@@ -1,13 +1,38 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Options;
+using ZeeKer.Crafty.Configuration;
+using ZeeKer.Crafty.Infrastructure.Clients;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
-
 builder.Services.AddControllers();
+
+builder.Services.Configure<CraftyControllerOptions>(builder.Configuration.GetSection("CraftyController"));
+
+builder.Services.AddHttpClient<ICraftyControllerClient, CraftyControllerClient>((sp, client) =>
+{
+    var options = sp.GetRequiredService<IOptions<CraftyControllerOptions>>().Value;
+
+    if (!string.IsNullOrWhiteSpace(options.BaseUrl))
+    {
+        if (!Uri.TryCreate(options.BaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            throw new InvalidOperationException("CraftyController BaseUrl is invalid.");
+        }
+
+        client.BaseAddress = baseUri;
+    }
+
+    if (!string.IsNullOrWhiteSpace(options.ApiKey))
+    {
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.ApiKey);
+    }
+});
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-
 app.UseAuthorization();
 
 app.MapControllers();

--- a/ZeeKer.Crafty.Bot/appsettings.Development.json
+++ b/ZeeKer.Crafty.Bot/appsettings.Development.json
@@ -4,5 +4,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "CraftyController": {
+    "BaseUrl": "https://crafty.example.com/api/",
+    "ApiKey": "CHANGE_ME",
+    "ServersEndpoint": "servers"
   }
 }

--- a/ZeeKer.Crafty.Bot/appsettings.json
+++ b/ZeeKer.Crafty.Bot/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "CraftyController": {
+    "BaseUrl": "https://crafty.example.com/api/",
+    "ApiKey": "CHANGE_ME",
+    "ServersEndpoint": "servers"
+  }
 }

--- a/ZeeKer.Crafty.Infrastructure/Clients/CraftyControllerClient.cs
+++ b/ZeeKer.Crafty.Infrastructure/Clients/CraftyControllerClient.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Options;
+using ZeeKer.Crafty.Configuration;
+using ZeeKer.Crafty.Dtos;
+
+namespace ZeeKer.Crafty.Infrastructure.Clients;
+
+public sealed class CraftyControllerClient : ICraftyControllerClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IOptionsMonitor<CraftyControllerOptions> _optionsMonitor;
+
+    public CraftyControllerClient(HttpClient httpClient, IOptionsMonitor<CraftyControllerOptions> optionsMonitor)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _optionsMonitor = optionsMonitor ?? throw new ArgumentNullException(nameof(optionsMonitor));
+    }
+
+    public async Task<int> GetTotalOnlineAsync(CancellationToken cancellationToken = default)
+    {
+        var options = _optionsMonitor.CurrentValue;
+
+        if (string.IsNullOrWhiteSpace(options.ServersEndpoint))
+        {
+            throw new InvalidOperationException("CraftyController options are not configured correctly.");
+        }
+
+        if (_httpClient.BaseAddress is null && !Uri.IsWellFormedUriString(options.ServersEndpoint, UriKind.Absolute))
+        {
+            throw new InvalidOperationException("CraftyController base address is not configured correctly.");
+        }
+
+        using var response = await _httpClient.GetAsync(options.ServersEndpoint, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"CraftyController responded with {(int)response.StatusCode} ({response.ReasonPhrase}). Body: {errorBody}",
+                null,
+                response.StatusCode);
+        }
+
+        var servers = await response.Content.ReadFromJsonAsync<IReadOnlyCollection<ServerDto>>(cancellationToken: cancellationToken);
+        if (servers is null)
+        {
+            return 0;
+        }
+
+        return servers.Sum(server => server?.PlayersOnline ?? 0);
+    }
+}

--- a/ZeeKer.Crafty.Infrastructure/Clients/ICraftyControllerClient.cs
+++ b/ZeeKer.Crafty.Infrastructure/Clients/ICraftyControllerClient.cs
@@ -1,0 +1,6 @@
+namespace ZeeKer.Crafty.Infrastructure.Clients;
+
+public interface ICraftyControllerClient
+{
+    Task<int> GetTotalOnlineAsync(CancellationToken cancellationToken = default);
+}

--- a/ZeeKer.Crafty/Configuration/CraftyControllerOptions.cs
+++ b/ZeeKer.Crafty/Configuration/CraftyControllerOptions.cs
@@ -1,0 +1,10 @@
+namespace ZeeKer.Crafty.Configuration;
+
+public record class CraftyControllerOptions
+{
+    public string BaseUrl { get; init; } = string.Empty;
+
+    public string ApiKey { get; init; } = string.Empty;
+
+    public string ServersEndpoint { get; init; } = string.Empty;
+}

--- a/ZeeKer.Crafty/Dtos/ServerDto.cs
+++ b/ZeeKer.Crafty/Dtos/ServerDto.cs
@@ -1,0 +1,6 @@
+namespace ZeeKer.Crafty.Dtos;
+
+public sealed record ServerDto
+{
+    public int PlayersOnline { get; init; }
+}


### PR DESCRIPTION
## Summary
- configure CraftyController settings for the bot application
- add options and DTO types to support CraftyController integration
- implement the CraftyController HTTP client and expose a status endpoint for total online players

## Testing
- dotnet build ZeeKer.Crafty.Bot.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcb3026748328ac20472937e92627