### PR TITLE
Expand Crafty status endpoint with server statistics

### DIFF
--- a/ZeeKer.Crafty.Bot/Controllers/CraftyStatusController.cs
+++ b/ZeeKer.Crafty.Bot/Controllers/CraftyStatusController.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Net.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
@@ -23,8 +24,14 @@ public class CraftyStatusController : ControllerBase
     {
         try
         {
-            var totalOnline = await _craftyControllerClient.GetTotalOnlineAsync(cancellationToken);
-            return Ok(new { totalOnline });
+            var serverStatistics = await _craftyControllerClient.GetServerStatisticsAsync(cancellationToken);
+            var totalOnline = serverStatistics.Sum(static stats => stats.Online);
+
+            return Ok(new
+            {
+                totalOnline,
+                servers = serverStatistics
+            });
         }
         catch (HttpRequestException ex)
         {

--- a/ZeeKer.Crafty.Infrastructure/Clients/ICraftyControllerClient.cs
+++ b/ZeeKer.Crafty.Infrastructure/Clients/ICraftyControllerClient.cs
@@ -1,6 +1,8 @@
+using ZeeKer.Crafty.Dtos;
+
 namespace ZeeKer.Crafty.Infrastructure.Clients;
 
 public interface ICraftyControllerClient
 {
-    Task<int> GetTotalOnlineAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<ServerStatisticsDto>> GetServerStatisticsAsync(CancellationToken cancellationToken = default);
 }

--- a/ZeeKer.Crafty/Dtos/CraftyResponse.cs
+++ b/ZeeKer.Crafty/Dtos/CraftyResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace ZeeKer.Crafty.Dtos;
+
+public sealed record CraftyResponse<T>
+{
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+
+    [JsonPropertyName("data")]
+    public T? Data { get; init; }
+}

--- a/ZeeKer.Crafty/Dtos/ServerDto.cs
+++ b/ZeeKer.Crafty/Dtos/ServerDto.cs
@@ -1,6 +1,9 @@
+using System.Text.Json.Serialization;
+
 namespace ZeeKer.Crafty.Dtos;
 
 public sealed record ServerDto
 {
-    public int PlayersOnline { get; init; }
+    [JsonPropertyName("server_id")]
+    public int ServerId { get; init; }
 }

--- a/ZeeKer.Crafty/Dtos/ServerStatisticsDto.cs
+++ b/ZeeKer.Crafty/Dtos/ServerStatisticsDto.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ZeeKer.Crafty.Dtos;
+
+public sealed record ServerStatisticsDto
+{
+    [JsonPropertyName("stats_id")]
+    public int StatsId { get; init; }
+
+    [JsonPropertyName("created")]
+    public DateTime Created { get; init; }
+
+    [JsonPropertyName("server_id")]
+    public JsonElement Server { get; init; }
+
+    [JsonPropertyName("started")]
+    public string? Started { get; init; }
+
+    [JsonPropertyName("running")]
+    public bool Running { get; init; }
+
+    [JsonPropertyName("cpu")]
+    public double? Cpu { get; init; }
+
+    [JsonPropertyName("mem")]
+    public string? Memory { get; init; }
+
+    [JsonPropertyName("mem_percent")]
+    public double? MemoryPercent { get; init; }
+
+    [JsonPropertyName("world_name")]
+    public string? WorldName { get; init; }
+
+    [JsonPropertyName("world_size")]
+    public string? WorldSize { get; init; }
+
+    [JsonPropertyName("server_port")]
+    public int? ServerPort { get; init; }
+
+    [JsonPropertyName("int_ping_results")]
+    public string? InternalPingResults { get; init; }
+
+    [JsonPropertyName("online")]
+    public int Online { get; init; }
+
+    [JsonPropertyName("max")]
+    public int? MaxPlayers { get; init; }
+
+    [JsonPropertyName("players")]
+    public JsonElement Players { get; init; }
+
+    [JsonPropertyName("desc")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    [JsonPropertyName("updating")]
+    public bool Updating { get; init; }
+
+    [JsonPropertyName("waiting_start")]
+    public bool WaitingStart { get; init; }
+
+    [JsonPropertyName("first_run")]
+    public bool FirstRun { get; init; }
+
+    [JsonPropertyName("crashed")]
+    public bool Crashed { get; init; }
+
+    [JsonPropertyName("downloading")]
+    public bool Downloading { get; init; }
+}


### PR DESCRIPTION
## Summary
- update the Crafty status endpoint to return aggregated totals together with per-server statistics
- extend the Crafty client with DTOs and logic to retrieve server statistics from the API

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcf0b2c988328a35f8cdea015c4fb