### PR TITLE
Add Telegram bot configuration support

### DIFF
--- a/ZeeKer.Crafty.Bot/Program.cs
+++ b/ZeeKer.Crafty.Bot/Program.cs
@@ -15,6 +15,10 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.Configure<CraftyControllerOptions>(
     builder.Configuration.GetSection("CraftyController"));
+builder.Services.Configure<TelegramBotOptions>(
+    builder.Configuration.GetSection("TelegramBot"));
+builder.Services.AddOptions<TelegramBotOptions>()
+    .ValidateDataAnnotations();
 
 builder.Services.AddHttpClient<ICraftyControllerClient, CraftyControllerClient>((sp, client) =>
 {

--- a/ZeeKer.Crafty.Bot/appsettings.Development.json
+++ b/ZeeKer.Crafty.Bot/appsettings.Development.json
@@ -8,5 +8,10 @@
   "CraftyController": {
     "BaseUrl": null,
     "ApiKey": null
+  },
+  "TelegramBot": {
+    "Token": null,
+    "ChatId": null,
+    "UpdateIntervalMinutes": 1
   }
 }

--- a/ZeeKer.Crafty.Bot/appsettings.json
+++ b/ZeeKer.Crafty.Bot/appsettings.json
@@ -9,5 +9,10 @@
   "CraftyController": {
     "BaseUrl": null,
     "ApiKey": null
+  },
+  "TelegramBot": {
+    "Token": null,
+    "ChatId": null,
+    "UpdateIntervalMinutes": 1
   }
 }

--- a/ZeeKer.Crafty/Configuration/TelegramBotOptions.cs
+++ b/ZeeKer.Crafty/Configuration/TelegramBotOptions.cs
@@ -1,0 +1,15 @@
+namespace ZeeKer.Crafty.Configuration;
+
+using System.ComponentModel.DataAnnotations;
+
+public record class TelegramBotOptions
+{
+    [Required]
+    public string Token { get; init; } = string.Empty;
+
+    [Required]
+    public string ChatId { get; init; } = string.Empty;
+
+    [Range(1, int.MaxValue, ErrorMessage = "UpdateIntervalMinutes must be greater than zero.")]
+    public int UpdateIntervalMinutes { get; init; } = 1;
+}


### PR DESCRIPTION
## Summary
- add a TelegramBotOptions configuration record with basic validation attributes
- extend the default and development appsettings with a TelegramBot section
- register the TelegramBot options for dependency injection

## Testing
- not run (dotnet CLI not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dbde1c76e48328add38da836e3c31e