### PR TITLE
Add Telegram bot notifier service

### DIFF
--- a/ZeeKer.Crafty.Bot/Messaging/TelegramNotifier.cs
+++ b/ZeeKer.Crafty.Bot/Messaging/TelegramNotifier.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+using ZeeKer.Crafty.Configuration;
+
+namespace ZeeKer.Crafty.Bot.Messaging;
+
+public interface ITelegramNotifier
+{
+    Task SendMessageAsync(string message, CancellationToken cancellationToken = default);
+}
+
+public sealed class TelegramNotifier : ITelegramNotifier
+{
+    private readonly ITelegramBotClient _client;
+    private readonly TelegramBotOptions _options;
+    private readonly ILogger<TelegramNotifier> _logger;
+
+    public TelegramNotifier(
+        ITelegramBotClient client,
+        IOptions<TelegramBotOptions> options,
+        ILogger<TelegramNotifier> logger)
+    {
+        _client = client;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task SendMessageAsync(string message, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _client.SendTextMessageAsync(
+                chatId: _options.ChatId,
+                text: message,
+                cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send Telegram message.");
+            throw;
+        }
+    }
+}

--- a/ZeeKer.Crafty.Bot/Program.cs
+++ b/ZeeKer.Crafty.Bot/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Options;
+using Telegram.Bot;
 using System.Net.Http.Headers;
+using ZeeKer.Crafty.Bot.Messaging;
 using ZeeKer.Crafty.Configuration;
 using ZeeKer.Crafty.Infrastructure.Clients;
 
@@ -19,6 +21,14 @@ builder.Services.Configure<TelegramBotOptions>(
     builder.Configuration.GetSection("TelegramBot"));
 builder.Services.AddOptions<TelegramBotOptions>()
     .ValidateDataAnnotations();
+
+builder.Services.AddSingleton<ITelegramBotClient>(sp =>
+{
+    var options = sp.GetRequiredService<IOptions<TelegramBotOptions>>().Value;
+    return new TelegramBotClient(options.Token);
+});
+
+builder.Services.AddSingleton<ITelegramNotifier, TelegramNotifier>();
 
 builder.Services.AddHttpClient<ICraftyControllerClient, CraftyControllerClient>((sp, client) =>
 {

--- a/ZeeKer.Crafty.Bot/ZeeKer.Crafty.Bot.csproj
+++ b/ZeeKer.Crafty.Bot/ZeeKer.Crafty.Bot.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.5" />
+    <PackageReference Include="Telegram.Bot" Version="19.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add the Telegram.Bot package to the bot project
- introduce an ITelegramNotifier wrapper around ITelegramBotClient for message sending
- register the Telegram bot client and notifier with dependency injection

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbdeed8400832896ac060198f7ff2b