### PR TITLE
Add formatter for server statistics with tests

### DIFF
--- a/ZeeKer.Crafty.Bot.Tests/Messaging/ServerStatisticsMessageBuilderTests.cs
+++ b/ZeeKer.Crafty.Bot.Tests/Messaging/ServerStatisticsMessageBuilderTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Text.Json;
+using Xunit;
+using ZeeKer.Crafty.Bot.Messaging;
+using ZeeKer.Crafty.Dtos;
+
+namespace ZeeKer.Crafty.Bot.Tests.Messaging;
+
+public sealed class ServerStatisticsMessageBuilderTests
+{
+    [Fact]
+    public void Build_ShouldFormatSummaryAndServerBlocks()
+    {
+        // Arrange
+        var statistics = new[]
+        {
+            CreateStatistics(
+                statsId: 1,
+                serverJson: "{\"server_name\":\"Beta\"}",
+                online: 5,
+                maxPlayers: null,
+                running: false,
+                worldName: null,
+                worldSize: null,
+                cpu: null,
+                memory: null,
+                memoryPercent: null,
+                version: null,
+                started: null,
+                flags: (updating: false, waitingStart: false, firstRun: false, crashed: false, downloading: false)),
+            CreateStatistics(
+                statsId: 2,
+                serverJson: "{\"server_name\":\"Alpha\"}",
+                online: 10,
+                maxPlayers: 20,
+                running: true,
+                worldName: "Earth",
+                worldSize: "1.2 GB",
+                cpu: 42.5,
+                memory: "1.5 GB",
+                memoryPercent: 75,
+                version: "1.20.4",
+                started: "2024-05-01T10:00:00Z",
+                flags: (updating: true, waitingStart: false, firstRun: false, crashed: false, downloading: false))
+        };
+
+        var builder = new ServerStatisticsMessageBuilder();
+
+        // Act
+        var result = builder.Build(statistics);
+
+        // Assert
+        var expected = """
+Crafty Server Summary
+Total servers: 2
+Total players online: 15
+
+- Alpha (Running)
+  Players: 10/20
+  World: Earth (1.2 GB)
+  CPU: 42.5%
+  Memory: 1.5 GB (75%)
+  Version: 1.20.4
+  Started: 2024-05-01T10:00:00Z
+  Flags: Updating
+
+- Beta (Stopped)
+  Players: 5/?
+  World: n/a
+  CPU: n/a
+  Memory: n/a
+  Version: n/a
+  Started: n/a
+  Flags: None
+""";
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Build_WhenStatisticsEmpty_ShouldReturnPlaceholder()
+    {
+        var builder = new ServerStatisticsMessageBuilder();
+
+        var result = builder.Build([]);
+
+        Assert.Equal("No server statistics available.", result);
+    }
+
+    private static ServerStatisticsDto CreateStatistics(
+        int statsId,
+        string serverJson,
+        int online,
+        int? maxPlayers,
+        bool running,
+        string? worldName,
+        string? worldSize,
+        double? cpu,
+        string? memory,
+        double? memoryPercent,
+        string? version,
+        string? started,
+        (bool updating, bool waitingStart, bool firstRun, bool crashed, bool downloading) flags)
+    {
+        return new ServerStatisticsDto
+        {
+            StatsId = statsId,
+            Created = DateTime.UtcNow,
+            Server = ParseJson(serverJson),
+            Started = started,
+            Running = running,
+            Cpu = cpu,
+            Memory = memory,
+            MemoryPercent = memoryPercent,
+            WorldName = worldName,
+            WorldSize = worldSize,
+            ServerPort = 25565,
+            InternalPingResults = null,
+            Online = online,
+            MaxPlayers = maxPlayers,
+            Players = ParseJson("[]"),
+            Description = null,
+            Version = version,
+            Updating = flags.updating,
+            WaitingStart = flags.waitingStart,
+            FirstRun = flags.firstRun,
+            Crashed = flags.crashed,
+            Downloading = flags.downloading
+        };
+    }
+
+    private static JsonElement ParseJson(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/ZeeKer.Crafty.Bot.Tests/ZeeKer.Crafty.Bot.Tests.csproj
+++ b/ZeeKer.Crafty.Bot.Tests/ZeeKer.Crafty.Bot.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ZeeKer.Crafty.Bot\ZeeKer.Crafty.Bot.csproj" />
+  </ItemGroup>
+</Project>

--- a/ZeeKer.Crafty.Bot.sln
+++ b/ZeeKer.Crafty.Bot.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZeeKer.Crafty", "ZeeKer.Cra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZeeKer.Crafty.Infrastructure", "ZeeKer.Crafty.Infrastructure\ZeeKer.Crafty.Infrastructure.csproj", "{72F600AF-7D8E-4B27-A461-93EFEF2FB85D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ZeeKer.Crafty.Bot.Tests", "ZeeKer.Crafty.Bot.Tests\ZeeKer.Crafty.Bot.Tests.csproj", "{8FC12882-0E52-43F6-84C2-EF160BD8BB11}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{72F600AF-7D8E-4B27-A461-93EFEF2FB85D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{72F600AF-7D8E-4B27-A461-93EFEF2FB85D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72F600AF-7D8E-4B27-A461-93EFEF2FB85D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FC12882-0E52-43F6-84C2-EF160BD8BB11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FC12882-0E52-43F6-84C2-EF160BD8BB11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FC12882-0E52-43F6-84C2-EF160BD8BB11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FC12882-0E52-43F6-84C2-EF160BD8BB11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ZeeKer.Crafty.Bot/Messaging/ServerStatisticsMessageBuilder.cs
+++ b/ZeeKer.Crafty.Bot/Messaging/ServerStatisticsMessageBuilder.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using ZeeKer.Crafty.Dtos;
+
+namespace ZeeKer.Crafty.Bot.Messaging;
+
+public sealed class ServerStatisticsMessageBuilder
+{
+    private static readonly string[] FlagLabels =
+    [
+        "Updating",
+        "Waiting start",
+        "First run",
+        "Crashed",
+        "Downloading"
+    ];
+
+    public string Build(IEnumerable<ServerStatisticsDto> statistics)
+    {
+        if (statistics is null)
+        {
+            throw new ArgumentNullException(nameof(statistics));
+        }
+
+        var stats = statistics
+            .Where(static stat => stat is not null)
+            .ToList();
+
+        if (stats.Count == 0)
+        {
+            return "No server statistics available.";
+        }
+
+        var totalPlayers = stats.Sum(static stat => stat.Online);
+
+        var builder = new StringBuilder();
+        builder.AppendLine("Crafty Server Summary");
+        builder.AppendLine($"Total servers: {stats.Count}");
+        builder.AppendLine($"Total players online: {totalPlayers}");
+        builder.AppendLine();
+
+        foreach (var stat in stats.OrderBy(GetServerName, StringComparer.OrdinalIgnoreCase))
+        {
+            var serverName = GetServerName(stat);
+            builder.Append("- ")
+                .Append(serverName)
+                .Append(" (")
+                .Append(stat.Running ? "Running" : "Stopped")
+                .AppendLine(")");
+
+            builder.Append("  Players: ")
+                .Append(stat.Online)
+                .Append('/')
+                .AppendLine(stat.MaxPlayers?.ToString(CultureInfo.InvariantCulture) ?? "?");
+
+            builder.Append("  World: ")
+                .AppendLine(FormatWorld(stat));
+
+            builder.Append("  CPU: ")
+                .AppendLine(FormatPercentage(stat.Cpu));
+
+            builder.Append("  Memory: ")
+                .AppendLine(FormatMemory(stat));
+
+            builder.Append("  Version: ")
+                .AppendLine(!string.IsNullOrWhiteSpace(stat.Version) ? stat.Version : "n/a");
+
+            builder.Append("  Started: ")
+                .AppendLine(!string.IsNullOrWhiteSpace(stat.Started) ? stat.Started : "n/a");
+
+            builder.Append("  Flags: ")
+                .AppendLine(FormatFlags(stat));
+
+            builder.AppendLine();
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string GetServerName(ServerStatisticsDto statistics)
+    {
+        if (statistics.Server.ValueKind == JsonValueKind.Object)
+        {
+            if (TryGetPropertyAsString(statistics.Server, "server_name", out var serverName) && !string.IsNullOrWhiteSpace(serverName))
+            {
+                return serverName!;
+            }
+
+            if (TryGetPropertyAsString(statistics.Server, "name", out var name) && !string.IsNullOrWhiteSpace(name))
+            {
+                return name!;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(statistics.Description))
+        {
+            return statistics.Description!;
+        }
+
+        return $"Server #{statistics.StatsId}";
+    }
+
+    private static bool TryGetPropertyAsString(JsonElement element, string propertyName, out string? value)
+    {
+        if (element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String)
+        {
+            value = property.GetString();
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    private static string FormatWorld(ServerStatisticsDto statistics)
+    {
+        var hasWorldName = !string.IsNullOrWhiteSpace(statistics.WorldName);
+        var hasWorldSize = !string.IsNullOrWhiteSpace(statistics.WorldSize);
+
+        if (!hasWorldName && !hasWorldSize)
+        {
+            return "n/a";
+        }
+
+        if (hasWorldName && hasWorldSize)
+        {
+            return $"{statistics.WorldName} ({statistics.WorldSize})";
+        }
+
+        return hasWorldName ? statistics.WorldName! : statistics.WorldSize!;
+    }
+
+    private static string FormatPercentage(double? value)
+    {
+        if (!value.HasValue)
+        {
+            return "n/a";
+        }
+
+        return FormattableString.Invariant($"{value.Value:0.##}%");
+    }
+
+    private static string FormatMemory(ServerStatisticsDto statistics)
+    {
+        var hasMemoryValue = !string.IsNullOrWhiteSpace(statistics.Memory);
+        var memoryPercent = statistics.MemoryPercent.HasValue
+            ? FormattableString.Invariant($"{statistics.MemoryPercent.Value:0.##}%")
+            : null;
+
+        return (hasMemoryValue, memoryPercent) switch
+        {
+            (false, null) => "n/a",
+            (true, null) => statistics.Memory!,
+            (false, not null) => memoryPercent!,
+            (true, not null) => $"{statistics.Memory} ({memoryPercent})"
+        };
+    }
+
+    private static string FormatFlags(ServerStatisticsDto statistics)
+    {
+        var flags = new List<string>(5);
+
+        if (statistics.Updating)
+        {
+            flags.Add(FlagLabels[0]);
+        }
+
+        if (statistics.WaitingStart)
+        {
+            flags.Add(FlagLabels[1]);
+        }
+
+        if (statistics.FirstRun)
+        {
+            flags.Add(FlagLabels[2]);
+        }
+
+        if (statistics.Crashed)
+        {
+            flags.Add(FlagLabels[3]);
+        }
+
+        if (statistics.Downloading)
+        {
+            flags.Add(FlagLabels[4]);
+        }
+
+        return flags.Count == 0 ? "None" : string.Join(", ", flags);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `ServerStatisticsMessageBuilder` that aggregates player counts and server metrics into a formatted message
- create an xUnit test project that verifies the formatter output and guards empty statistics handling
- register the test project in the solution for future runs

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe16a8c448328a6a89aa55ac07560