### PR TITLE
Add background service broadcasting Crafty status updates

### DIFF
--- a/ZeeKer.Crafty.Bot/Program.cs
+++ b/ZeeKer.Crafty.Bot/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Telegram.Bot;
 using System.Net.Http.Headers;
 using ZeeKer.Crafty.Bot.Messaging;
+using ZeeKer.Crafty.Bot.Services;
 using ZeeKer.Crafty.Configuration;
 using ZeeKer.Crafty.Infrastructure.Clients;
 
@@ -29,6 +30,8 @@ builder.Services.AddSingleton<ITelegramBotClient>(sp =>
 });
 
 builder.Services.AddSingleton<ITelegramNotifier, TelegramNotifier>();
+builder.Services.AddSingleton<ServerStatisticsMessageBuilder>();
+builder.Services.AddHostedService<CraftyStatusBroadcastService>();
 
 builder.Services.AddHttpClient<ICraftyControllerClient, CraftyControllerClient>((sp, client) =>
 {

--- a/ZeeKer.Crafty.Bot/Services/CraftyStatusBroadcastService.cs
+++ b/ZeeKer.Crafty.Bot/Services/CraftyStatusBroadcastService.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot.Exceptions;
+using ZeeKer.Crafty.Bot.Messaging;
+using ZeeKer.Crafty.Configuration;
+using ZeeKer.Crafty.Infrastructure.Clients;
+
+namespace ZeeKer.Crafty.Bot.Services;
+
+public sealed class CraftyStatusBroadcastService : BackgroundService
+{
+    private readonly ICraftyControllerClient _craftyControllerClient;
+    private readonly ITelegramNotifier _telegramNotifier;
+    private readonly TelegramBotOptions _options;
+    private readonly ILogger<CraftyStatusBroadcastService> _logger;
+    private readonly ServerStatisticsMessageBuilder _messageBuilder;
+
+    public CraftyStatusBroadcastService(
+        ICraftyControllerClient craftyControllerClient,
+        ITelegramNotifier telegramNotifier,
+        IOptions<TelegramBotOptions> options,
+        ILogger<CraftyStatusBroadcastService> logger,
+        ServerStatisticsMessageBuilder messageBuilder)
+    {
+        _craftyControllerClient = craftyControllerClient;
+        _telegramNotifier = telegramNotifier;
+        _options = options.Value;
+        _logger = logger;
+        _messageBuilder = messageBuilder;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var intervalMinutes = Math.Max(1, _options.UpdateIntervalMinutes);
+        var interval = TimeSpan.FromMinutes(intervalMinutes);
+
+        using var timer = new PeriodicTimer(interval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await BroadcastStatusAsync(stoppingToken).ConfigureAwait(false);
+
+            try
+            {
+                await timer.WaitForNextTickAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task BroadcastStatusAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var statistics = await _craftyControllerClient
+                .GetServerStatisticsAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var message = _messageBuilder.Build(statistics);
+
+            await _telegramNotifier.SendMessageAsync(message, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve Crafty server statistics.");
+        }
+        catch (ApiRequestException ex)
+        {
+            _logger.LogError(ex, "Failed to send Crafty status update to Telegram.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error during Crafty status broadcast.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a background service that periodically fetches Crafty server statistics and sends a Telegram summary
- register the service along with the server statistics message builder in the application DI container

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe4413894832888b324164d7dbbc6