### PR TITLE
Add Telegram chat state domain abstractions

### DIFF
--- a/ZeeKer.Crafty.Bot/ZeeKer.Crafty.Bot.csproj
+++ b/ZeeKer.Crafty.Bot/ZeeKer.Crafty.Bot.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ZeeKer.Crafty.Infrastructure\ZeeKer.Crafty.Infrastructure.csproj" />
+    <ProjectReference Include="..\ZeeKer.Crafty\ZeeKer.Crafty.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ZeeKer.Crafty/Messaging/ITelegramChatStateRepository.cs
+++ b/ZeeKer.Crafty/Messaging/ITelegramChatStateRepository.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ZeeKer.Crafty.Messaging;
+
+public interface ITelegramChatStateRepository
+{
+    Task<IReadOnlyCollection<TelegramChatState>> GetAllAsync(CancellationToken cancellationToken);
+
+    Task UpsertAsync(TelegramChatState state, CancellationToken cancellationToken);
+}

--- a/ZeeKer.Crafty/Messaging/TelegramChatState.cs
+++ b/ZeeKer.Crafty/Messaging/TelegramChatState.cs
@@ -1,0 +1,3 @@
+namespace ZeeKer.Crafty.Messaging;
+
+public sealed record TelegramChatState(long ChatId, int LastMessageId);


### PR DESCRIPTION
## Summary
- add the TelegramChatState record to represent stored chat metadata
- define ITelegramChatStateRepository for retrieving and upserting chat states
- expose the ZeeKer.Crafty domain project to the bot project through a project reference

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbf6306ee883289c63c73f824afdcd