### PR TITLE
Configure SQLite context initialization

### DIFF
--- a/ZeeKer.Crafty.Bot/ZeeKer.Crafty.Bot.csproj
+++ b/ZeeKer.Crafty.Bot/ZeeKer.Crafty.Bot.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.5" />
     <PackageReference Include="Telegram.Bot" Version="19.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/ZeeKer.Crafty.Bot/appsettings.Development.json
+++ b/ZeeKer.Crafty.Bot/appsettings.Development.json
@@ -5,6 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ConnectionStrings": {
+    "TelegramBot": "Data Source=craftybot.db"
+  },
   "CraftyController": {
     "BaseUrl": null,
     "ApiKey": null

--- a/ZeeKer.Crafty.Bot/appsettings.json
+++ b/ZeeKer.Crafty.Bot/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "TelegramBot": "Data Source=telegram-bot.db"
+    "TelegramBot": "Data Source=craftybot.db"
   },
   "CraftyController": {
     "BaseUrl": null,


### PR DESCRIPTION
## Summary
- add SQLite connection strings to the bot configuration files
- configure the bot's DbContext factory to resolve the SQLite path from the content root and run migrations at startup
- reference Microsoft.Data.Sqlite for connection string handling

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbfa8361dc83289db1f61ea5d985ea